### PR TITLE
Debug Stage.js issue

### DIFF
--- a/app/components/PreferencesView.js
+++ b/app/components/PreferencesView.js
@@ -28,15 +28,6 @@ export default class PreferencesView extends Component {
   render() {
     const { props, state } = this
     return(
-      <View style={{backgroundColor: 'hotpink', flex: 1, justifyContent: 'center'}}>
-        <TouchableOpacity onPress={() => props.fuck()}>
-          <Text>Hey</Text>
-        </TouchableOpacity>
-      </View>
-    )
-
-
-    return(
       <View style={{flex: 1}}>
         <Image source={{uri: props.user.photos[0].url}} resizeMode='cover' style={style.background} />
         <BlurView style={style.blur}

--- a/app/containers/Preferences.js
+++ b/app/containers/Preferences.js
@@ -74,9 +74,6 @@ function mapStateToProps() {
 
 function mapDispatchToProps(dispatch) {
   return {
-    fuck: () => {
-      dispatch({type: 'scene:change', scene: 'whatever'})
-    }
   }
 }
 

--- a/app/containers/Stage.js
+++ b/app/containers/Stage.js
@@ -43,11 +43,11 @@ class Stage extends PureComponent {
       <Login />
     :
       <View style={[style.container]}>
-        { this.showScene(props.scene) }
+        { this.showScene(props.sceneName) }
       </View>
   }
 
-  showScene(scene) {
+  showScene(sceneName) {
     const {props} = this
 
     if (!props.authenticated) {
@@ -57,7 +57,7 @@ class Stage extends PureComponent {
     if( !props.isActive ) {
       return !props.gender ?
         <GenderSelector />
-      : scene.name == 'VipCodeEntry' ?
+      : sceneName == 'VipCodeEntry' ?
         <VipCodeEntry />
       : props.vipCode ?
         <VipCodeStatus />
@@ -65,7 +65,7 @@ class Stage extends PureComponent {
         <Paywall />
     }
 
-    if( scene.name == 'PromoMaker' ) {
+    if( sceneName == 'PromoMaker' ) {
       return <PromoMaker />
     }
 
@@ -102,13 +102,24 @@ class Stage extends PureComponent {
 }
 
 function mapStateToProps(state) {
+  // TODO: this hack is here bc changing the scene
+  // makes this re-render, and re-rendering resets to the `initialSceneName`
+  // of Navigation.
+  var sceneName = state.scene && state.scene.name
+  switch(sceneName) {
+    case 'VipCodeEntry': case 'PromoMaker':
+      break;
+    default:
+      sceneName = 'Hack'
+  }
+
   return {
     authenticated: !!state.user.accessToken,
     isActive:      !!state.user.active,
     hydrated:      !!state.hydrated,
     isAdmin:       !!state.user.isAdmin,
     gender:        state.user.gender,
-    scene:         state.scene,
+    sceneName:     sceneName,
     vipCode:       state.vip.code,
   }
 }


### PR DESCRIPTION
Yeah so this is a real fishing wire and glue situation to a deeper problem. `Stage.js` and `Navigation.js` don't really coexist well, in that every time `Stage.js` re-renders, `Navigation` is reset to its initial view.

This glue fix makes it so that `Stage.js` only re-renders for certain scene names. But that neuters the usefulness of `Stage.js` which is that if you just want to show a view without putting it into the navigation hierarchy you can plug it in to `showScene`.

We can work off this for now, but I think the right way to approach the problem would be to either (a) make `Stage.js` and `Navigation.js` remember the state of `react-navigation` or (b) provide an easy way to show a view ad-hoc using `react-navigation`. 

Ideally we would do both, but either require more knowledge of `react-navigation` than I have currently or can learn tonight.