### PR TITLE
Allow gold tier users to send silver invites

### DIFF
--- a/app/actions/request.js
+++ b/app/actions/request.js
@@ -8,13 +8,13 @@
  * it generates a key for the results of the request and uses the `api` reducer to store
  * responses and errors.
  *
- * @param  {object} args:              args to passthru to fetch
- * @param  {string} args.url:          url specified as relative path of API base url
- * @param  {string} [args.method=GET]: http method
- * @param  {object} [args.headers]:         http headers
- * @param  {object|string} [args.body]:     json body
- * @param  {boolean} force:            whether we should do the request even if it's in progress
- * @return {promise}:                  result of fetch (error is not thrown)
+ * @param  {object} args:               args to passthru to fetch
+ * @param  {string} args.url:           url specified as relative path of API base url
+ * @param  {string} [args.method=GET]:  http method
+ * @param  {object} [args.headers]:     http headers
+ * @param  {object|string} [args.body]: json body
+ * @param  {boolean} force:             whether we should do the request even if it's in progress
+ * @return {promise}:                   result of fetch (error is not thrown)
  */
 
 import api    from '../services/api'

--- a/app/components/VipCodeInviteView.js
+++ b/app/components/VipCodeInviteView.js
@@ -19,13 +19,17 @@ export default function(props) {
         <Text>Cancel</Text>
       </TouchableOpacity>
 
-      <ButtonBlack text={`Send Invitation`} onPress={props.invite} style={styles.topButton} />
+      <ButtonBlack text={`Send Invitation`} style={styles.topButton}
+        onPress={() => props.generate('silver', 'Find your unicorn')} />
 
-      <TouchableHighlight style={[base.button, styles.secretButton]} underlayColor="hotpink" onPress={props.generate}>
-        <View>
-          <Text style={[base.buttonText, styles.secretButtonText]}>Send VIP Invitation</Text>
-        </View>
-      </TouchableHighlight>
+      { !props.isAdmin ? null :
+        <TouchableHighlight underlayColor="hotpink" style={[base.button, styles.secretButton]}
+          onPress={() => props.generate('gold', 'I think you\'re a unicorn')}>
+          <View>
+            <Text style={[base.buttonText, styles.secretButtonText]}>Send VIP Invitation</Text>
+          </View>
+        </TouchableHighlight>
+      }
     </View>
   )
 }

--- a/app/containers/VipCodeEntry.js
+++ b/app/containers/VipCodeEntry.js
@@ -62,7 +62,7 @@ function mapDispatchToProps(dispatch) {
   return {
     redeem: (code) => {
       return dispatch(request({
-        url:    `/promos/${code}`,
+        url:    `/vipCodes/${code}`,
         method: 'PUT',
       }))
     },


### PR DESCRIPTION
Closes #91 

So, unfortunately this is currently untestable unless you wait 24 hours and then hit the `promoter` endpoint. If we do end up delaying gold acceptance, we should provide a way to override that in development. `/promoter` takes an argument of `time` that would let us let in anyone waiting to be auto-approved in development. I wonder if we should have our own "Debug" menu in the client as I'm sure this won't be the last time we need to do something like this...lemme know your thoughts

![invite code screen](https://user-images.githubusercontent.com/83109/35077579-04bfc1f0-fbb3-11e7-841a-7e59bd57543a.gif)