### PR TITLE
Allow redirection to arbitrary website url based on push notifications

### DIFF
--- a/app/providers/NotificationProvider.js
+++ b/app/providers/NotificationProvider.js
@@ -25,8 +25,8 @@ class NotificationProvider extends Component {
     this.unsubscribe && this.unsubscribe()
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.isAuthenticated && !this.props.isAuthenticated) {
+  componentWillReceiveProps(props) {
+    if (props.isAuthenticated && !this.props.isAuthenticated) {
       firebase.messaging().getToken().then((token) => {
         this.props.saveToken(token)
       })
@@ -34,6 +34,10 @@ class NotificationProvider extends Component {
       firebase.messaging().onTokenRefresh((token) => {
         this.props.saveToken(token)
       })
+    }
+
+    if( props.isActive && !this.props.isActive ) {
+      firebase.messaging().subscribeToTopic('/topics/active')
     }
   }
 
@@ -49,6 +53,7 @@ class NotificationProvider extends Component {
 function mapStateToProps(state) {
   return {
     isAuthenticated: !!state.user.id,
+    isActive:        !!state.user.active,
   }
 }
 


### PR DESCRIPTION
Closes #89

So, it's a leetle bit janky in that if the app is open and you get a push, you'll just be sent to safari with no explanation of what's going on. Should be enough of an edge for now since no one is gonna have the waiting room open when we send marketing pushes.

I also did realize though that there isn't currently a way for us to target through the marketing console only people on the waiting list. So we should probably maintain topic subscriptions for those people. I'll try adding that here.