### PR TITLE
Fix up login transition

### DIFF
--- a/app/components/LoginView.js
+++ b/app/components/LoginView.js
@@ -143,44 +143,46 @@ export default class LoginView extends Component {
         <FairySheet count={8} colorFn={[mayteWhite, mayteGreen, maytePink, mayteBlue]} style={{opacity: this._fairyOp}}  />
 
         <View style={style.main}>
+          <View>
+            <Animated.View style={{alignItems: 'center', opacity: this._logoOpacity}}>
+              <Image style={[style.icon]}
+                     source={require('../images/unicorn-icon-white.png')}
+                     resizeMode="contain" />
+              <Image style={[style.logo]}
+                     source={require('../images/unicorn-logo-white.png')}
+                     resizeMode="contain" />
+            </Animated.View>
+
             { props.loading ?
               <ActivityIndicator size="large"/>
-            :
-            <View>
-              <Animated.View style={{alignItems: 'center', opacity: this._logoOpacity}}>
-                <Image style={[style.icon]}
-                       source={require('../images/unicorn-icon-white.png')}
-                       resizeMode="contain" />
-                <Image style={[style.logo]}
-                       source={require('../images/unicorn-logo-white.png')}
-                       resizeMode="contain" />
-              </Animated.View>
+            : !props.loadingDelay ?
+              <View>
+                <Animated.View
+                  style={{
+                    opacity: this._igOpacity,
+                    transform: [{translateY: this._igDriftY}]}}>
+                  <ButtonGrey
+                    text='LOGIN WITH INSTAGRAM'
+                    styleGrad={style.buttonGrad}
+                    styleText={style.buttonText}
+                    style={[style.button, {marginBottom: em(2.33)}]}
+                    onPress={props.instagramLogin} />
+                </Animated.View>
 
-              <Animated.View
-                style={{
-                  opacity: this._igOpacity,
-                  transform: [{translateY: this._igDriftY}]}}>
-                <ButtonGrey
-                  text='LOGIN WITH INSTAGRAM'
-                  styleGrad={style.buttonGrad}
-                  styleText={style.buttonText}
-                  style={[style.button, {marginBottom: em(2.33)}]}
-                  onPress={props.instagramLogin} />
-              </Animated.View>
-
-              <Animated.View
-                style={{
-                  opacity: this._liOpacity,
-                  transform: [{translateY: this._liDriftY}]}}>
-                <ButtonGrey
-                  text='LOGIN WITH LINKEDIN'
-                  styleGrad={style.buttonGrad}
-                  styleText={style.buttonText}
-                  style={[style.button]}
-                  onPress={props.linkedinLogin} />
-              </Animated.View>
-            </View>
-        }
+                <Animated.View
+                  style={{
+                    opacity: this._liOpacity,
+                    transform: [{translateY: this._liDriftY}]}}>
+                  <ButtonGrey
+                    text='LOGIN WITH LINKEDIN'
+                    styleGrad={style.buttonGrad}
+                    styleText={style.buttonText}
+                    style={[style.button]}
+                    onPress={props.linkedinLogin} />
+                </Animated.View>
+              </View>
+            : null }
+          </View>
         </View>
       </View>
     )

--- a/app/containers/Login.js
+++ b/app/containers/Login.js
@@ -23,6 +23,19 @@ class Login extends Component {
 
   componentWillUnmount() {
     Linking.removeEventListener('url', this.handle)
+    this.timeout && clearTimeout(this.timeout)
+  }
+
+  componentWillReceiveProps(props) {
+    if( props.loadingDelay != this.props.loadingDelay ) {
+      if( props.loadingDelay ) {
+        this.timeout = setTimeout(() => {
+          this.setState({loading: true})
+        }, 1000)
+      } else {
+        this.timeout && clearTimeout(this.timeout)
+      }
+    }
   }
 
   handle(event) {
@@ -35,8 +48,6 @@ class Login extends Component {
     if( !matches ) {
       return console.warn('No access token provided', event && event.url)
     }
-
-    this.setState({loading: true})
 
     this.props.hydrate(matches[1])
   }
@@ -65,6 +76,7 @@ class Login extends Component {
 
   render() { return (
     <LoginView {...this.props}
+               loading={this.state.loading}
                linkedinLogin={this.linkedinLogin}
                instagramLogin={this.instagramLogin} />
   )}
@@ -74,7 +86,7 @@ function mapStateToProps(state) {
   const apiCall = state.api['GET /users/me'] || {}
 
   return {
-    loading: apiCall.loading
+    loadingDelay: apiCall.loading
   }
 }
 

--- a/app/containers/Quiz.js
+++ b/app/containers/Quiz.js
@@ -4,6 +4,7 @@ import QuizView           from '../components/QuizView'
 import moment             from 'moment'
 import request            from '../actions/request'
 import api                from '../services/api'
+import logout             from '../actions/logout'
 import {
   Alert
 } from 'react-native'
@@ -103,7 +104,6 @@ class Quiz extends Component {
 
     return <QuizView {...props}
              zodiac={this.state.zodiac}
-             reset={this.reset}
              photosLoading={this.state.photosLoading}
              update={this.props.setQuiz}
              submit={this.submit}
@@ -159,7 +159,7 @@ const mapDispatchToProps = (dispatch) => {
       }))
     },
     resetQuiz: () => {
-      return dispatch({type: 'quiz:destroy'})
+      return dispatch(logout())
     },
     updateSelf: () => {
       return dispatch(request({


### PR DESCRIPTION
It's jarring to see all the elements on the screen disappear and showing an activity indicator immediately leads to decreased perceived performance. This removes only the login buttons and delays the appearance of the activity indicator

![login](https://user-images.githubusercontent.com/83109/35423615-7816b7ca-0203-11e8-802f-fc8a59d8a550.gif)
